### PR TITLE
Initial Unit Test setup

### DIFF
--- a/ScreenControl/Assets/ScreenControl/Core/Tests.meta
+++ b/ScreenControl/Assets/ScreenControl/Core/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1cd31ccc04180794ea24d8af3e352859
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ScreenControl/Assets/ScreenControl/Core/Tests/Editor.meta
+++ b/ScreenControl/Assets/ScreenControl/Core/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e72c67d94334469459de0c04c6587db4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ScreenControl/Assets/ScreenControl/Core/Tests/Editor/ScreenControlUtilityTest.cs
+++ b/ScreenControl/Assets/ScreenControl/Core/Tests/Editor/ScreenControlUtilityTest.cs
@@ -1,0 +1,116 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+using Ultraleap.ScreenControl.Core;
+
+namespace Tests
+{
+    public class ScreenControlUtilityTest
+    {
+        // A Test behaves as an ordinary method
+        [Test]
+        public void MapToRangeAtLowestBound()
+        {
+            float initial = 1.0f;
+
+            float initialMin = 1.0f;
+            float initialMax = 5.0f;
+
+            float newMin = 10.0f;
+            float newMax = 50.0f;
+
+            float expectedResult = newMin;
+
+            float result = ScreenControlUtility.MapRangeToRange(
+                initial,
+                initialMin,
+                initialMax,
+                newMin,
+                newMax);
+
+            Assert.True(Mathf.Approximately(result, expectedResult));
+        }
+
+        [Test]
+        public void MapToRangeAtHighestBound()
+        {
+            float initial = 5.0f;
+
+            float initialMin = 1.0f;
+            float initialMax = 5.0f;
+
+            float newMin = 10.0f;
+            float newMax = 50.0f;
+
+            float expectedResult = newMax;
+
+            float result = ScreenControlUtility.MapRangeToRange(
+                initial,
+                initialMin,
+                initialMax,
+                newMin,
+                newMax);
+
+            Assert.True(Mathf.Approximately(result, expectedResult));
+        }
+
+        [Test]
+        public void MapToRangeAtCentre()
+        {
+            float initial = 7.5f;
+
+            float initialMin = 5.0f;
+            float initialMax = 10.0f;
+
+            float newMin = 0.0f;
+            float newMax = 15.0f;
+
+            float expectedResult = initial;
+
+            float result = ScreenControlUtility.MapRangeToRange(
+                initial,
+                initialMin,
+                initialMax,
+                newMin,
+                newMax);
+
+            Assert.True(Mathf.Approximately(result, expectedResult));
+        }
+
+        [Test]
+        public void ParseColorFromHexNoAlpha()
+        {
+            string textColor = "#00ff00";
+
+            Color result = ScreenControlUtility.ParseColor(textColor);
+
+            Assert.AreEqual(Color.green, result);
+        }
+
+        [Test]
+        public void ParseColorDefaultAlphaOverride()
+        {
+            string textColor = "#00ff0000";
+
+            Color result = ScreenControlUtility.ParseColor(textColor);
+
+            Assert.AreEqual(Color.green, result);
+        }
+
+        [Test]
+        public void ParseColorCustomAlphaOverride()
+        {
+            string textColor = "#00ff007f";
+
+            Color result = ScreenControlUtility.ParseColor(textColor, 0.25f);
+
+            Assert.True(Mathf.Approximately(0.00f, result.r));
+            Assert.True(Mathf.Approximately(1.00f, result.g));
+            Assert.True(Mathf.Approximately(0.00f, result.b));
+            Assert.True(Mathf.Approximately(0.25f, result.a));
+        }
+    }
+}

--- a/ScreenControl/Assets/ScreenControl/Core/Tests/Editor/ScreenControlUtilityTest.cs.meta
+++ b/ScreenControl/Assets/ScreenControl/Core/Tests/Editor/ScreenControlUtilityTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c3b77b51c335fd4bab200740cf7a270
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Initial Setup of Unit Tests for Screen Control, proving out how we can do it.

Doesn't cover any Integration-level testing, which will come in on another ticket.