### PR TITLE
BL-583 Add DistanceFromScreen to InputActions

### DIFF
--- a/ScreenControl/Assets/ScreenControl/Client/Scripts/CoreConnection/DirectCoreConnection.cs
+++ b/ScreenControl/Assets/ScreenControl/Client/Scripts/CoreConnection/DirectCoreConnection.cs
@@ -28,6 +28,7 @@ namespace Ultraleap.ScreenControl.Client
                 (HandChirality)_data.Chirality,
                 (InputType)_data.InputType,
                 _data.CursorPosition,
+                _data.DistanceFromScreen,
                 _data.ProgressToClick);
 
             RelayInputAction(clientInput);

--- a/ScreenControl/Assets/ScreenControl/Client/Scripts/CoreConnection/WebSocketReceiverQueue.cs
+++ b/ScreenControl/Assets/ScreenControl/Client/Scripts/CoreConnection/WebSocketReceiverQueue.cs
@@ -19,19 +19,25 @@ namespace Ultraleap.ScreenControl.Client
             ClientInputAction action;
             while (receiveQueue.Count > queueCullLimit)
             {
-                receiveQueue.TryDequeue(out action);
-
-                // Stop skipping through the queue this frame if we have just handled a 'key' input event
-                if (action.InputType != InputType.MOVE)
+                if (receiveQueue.TryPeek(out action))
                 {
-                    coreConnection.HandleInputAction(action);
-                    return;
+                    receiveQueue.TryDequeue(out action);
+
+                    // Stop skipping through the queue this frame if we have just handled a 'key' input event
+                    if (action.InputType != InputType.MOVE)
+                    {
+                        coreConnection.HandleInputAction(action);
+                        return;
+                    }
                 }
             }
 
-            // Parse newly received messages
-            receiveQueue.TryDequeue(out action);
-            coreConnection.HandleInputAction(action);
+            if (receiveQueue.TryPeek(out action))
+            {
+                // Parse newly received messages
+                receiveQueue.TryDequeue(out action);
+                coreConnection.HandleInputAction(action);
+            }
         }
     }
 }

--- a/ScreenControl/Assets/ScreenControl/Client/Scripts/Cursors/DotCursor.cs
+++ b/ScreenControl/Assets/ScreenControl/Client/Scripts/Cursors/DotCursor.cs
@@ -89,14 +89,11 @@ namespace Ultraleap.ScreenControl.Client
         protected override void HandleInputAction(ScreenControlTypes.ClientInputAction _inputData)
         {
             base.HandleInputAction(_inputData);
-            ScreenControlTypes.InputType _type = _inputData.InputType;
-            Vector2 _cursorPosition = _inputData.CursorPosition;
-            float _distanceFromScreen = _inputData.ProgressToClick;
 
-            switch (_type)
+            switch (_inputData.InputType)
             {
                 case ScreenControlTypes.InputType.MOVE:
-                    UpdateCursor(_cursorPosition, _distanceFromScreen);
+                    UpdateCursor(_inputData.CursorPosition, _inputData.ProgressToClick);
                     break;
                 case ScreenControlTypes.InputType.DOWN:
                     growQueued = false;

--- a/ScreenControl/Assets/ScreenControl/Client/Scripts/ScreenControlTypes.cs
+++ b/ScreenControl/Assets/ScreenControl/Client/Scripts/ScreenControlTypes.cs
@@ -19,6 +19,7 @@ namespace Ultraleap.ScreenControl.Client
             public readonly HandChirality Chirality;
             public readonly InputType InputType;
             public readonly Vector2 CursorPosition;
+            public readonly float DistanceFromScreen;
             public readonly float ProgressToClick;
 
             public ClientInputAction(
@@ -28,6 +29,7 @@ namespace Ultraleap.ScreenControl.Client
                 HandChirality _chirality,
                 InputType _inputType,
                 Vector2 _cursorPosition,
+                float _distanceFromScreen,
                 float _progressToClick)
             {
                 Timestamp = _timestamp;
@@ -36,6 +38,7 @@ namespace Ultraleap.ScreenControl.Client
                 Chirality = _chirality;
                 InputType = _inputType;
                 CursorPosition = _cursorPosition;
+                DistanceFromScreen = _distanceFromScreen;
                 ProgressToClick = _progressToClick;
             }
 
@@ -47,6 +50,7 @@ namespace Ultraleap.ScreenControl.Client
                 Chirality = Utilities.GetChiralityFromFlags(_wsInput.InteractionFlags);
                 InputType = Utilities.GetInputTypeFromFlags(_wsInput.InteractionFlags);
                 CursorPosition = _wsInput.CursorPosition;
+                DistanceFromScreen = _wsInput.DistanceFromScreen;
                 ProgressToClick = _wsInput.ProgressToClick;
             }
         }
@@ -112,6 +116,7 @@ namespace Ultraleap.ScreenControl.Client
             public long Timestamp;
             public BitmaskFlags InteractionFlags;
             public Vector2 CursorPosition;
+            public float DistanceFromScreen;
             public float ProgressToClick;
 
             public WebsocketInputAction(ClientInputAction _data)
@@ -122,6 +127,7 @@ namespace Ultraleap.ScreenControl.Client
                                                                  _data.Chirality,
                                                                  _data.InputType);
                 CursorPosition = _data.CursorPosition;
+                DistanceFromScreen = _data.DistanceFromScreen;
                 ProgressToClick = _data.ProgressToClick;
             }
         }

--- a/ScreenControl/Assets/ScreenControl/Core/Scripts/Configuration/VirtualScreen.cs
+++ b/ScreenControl/Assets/ScreenControl/Core/Scripts/Configuration/VirtualScreen.cs
@@ -9,15 +9,12 @@ namespace Ultraleap.ScreenControl.Core
         public float Height_VirtualPx { get; private set; }
         public float Width_PhysicalMeters { get; private set; }
         public float Height_PhysicalMeters { get; private set; }
-        public float DistanceFromPhysicalScreen_Meters { get; private set; }
         /// <summary>
         /// The angle or tilt of the physical screen in degrees, where 0 would be a vertical screen facing the user, and 90 would be a flat screen facing the ceiling.
         /// </summary>
         public float AngleOfPhysicalScreen_Degrees { get; private set; }
 
         public Plane PhysicalScreenPlane { get; private set; }
-
-        public Plane VirtualScreenPlane { get; private set; }
 
         /// <summary>
         /// 
@@ -39,12 +36,9 @@ namespace Ultraleap.ScreenControl.Core
             var aspectRatio = (float)widthPx / (float)heightPx;
             Width_PhysicalMeters = heightPhysicalMeters * aspectRatio;
 
-            DistanceFromPhysicalScreen_Meters = SettingsConfig.Config.TouchPlaneDistanceFromScreenM;
-
             AngleOfPhysicalScreen_Degrees = physicalScreenAngleDegrees;
             var planeNormal = new Vector3(0f, Mathf.Sin(AngleOfPhysicalScreen_Degrees * Mathf.Deg2Rad), -Mathf.Cos(AngleOfPhysicalScreen_Degrees * Mathf.Deg2Rad));
             PhysicalScreenPlane = new Plane(-planeNormal, 0f);
-            VirtualScreenPlane = new Plane(-planeNormal, DistanceFromPhysicalScreen_Meters);
         }
 
         /// <summary>
@@ -68,9 +62,6 @@ namespace Ultraleap.ScreenControl.Core
             PhysicalScreenPlane.Raycast(r, out float distanceFromPlane);
             planeHitWorldPosition = r.origin + (r.direction * distanceFromPlane);
 
-            // Distance between the ray origin and the virtual screen plane.
-            var distanceFromVirtualPlane = distanceFromPlane - DistanceFromPhysicalScreen_Meters;
-
             // If the screen is rotated, this effectively scales down or "projects" the rotated screen vector back onto the UP axis, giving us the new UP axis height of the screen.
             var screenHeight = Height_PhysicalMeters * Mathf.Cos(AngleOfPhysicalScreen_Degrees * Mathf.Deg2Rad);
 
@@ -80,7 +71,7 @@ namespace Ultraleap.ScreenControl.Core
 
             screenPos.x = Width_VirtualPx * tX;
             screenPos.y = Height_VirtualPx * tY;
-            screenPos.z = distanceFromVirtualPlane;
+            screenPos.z = distanceFromPlane;
 
             return screenPos;
         }
@@ -97,7 +88,7 @@ namespace Ultraleap.ScreenControl.Core
 
             worldPos.x = (Width_PhysicalMeters * tX) - (Width_PhysicalMeters / 2.0f);
             worldPos.y = screenHeight * tY;
-            worldPos.z = distanceFromVirtualScreen + DistanceFromPhysicalScreen_Meters;
+            worldPos.z = distanceFromVirtualScreen;
 
             return worldPos;
         }

--- a/ScreenControl/Assets/ScreenControl/Core/Scripts/Interactions/InteractionModules/AirPushInteraction.cs
+++ b/ScreenControl/Assets/ScreenControl/Core/Scripts/Interactions/InteractionModules/AirPushInteraction.cs
@@ -130,7 +130,7 @@ namespace Ultraleap.ScreenControl.Core
                         pressing = false;
                         isDragging = false;
                         cursorPressPosition = Vector2.zero;
-                        SendInputAction(InputType.UP, positions, appliedForce);
+                        SendInputAction(InputType.UP, positions, positions.DistanceFromScreen, appliedForce);
                     }
                     else
                     {
@@ -142,7 +142,7 @@ namespace Ultraleap.ScreenControl.Core
                                 dragDeadzoneShrinkTriggered = true;
                             }
 
-                            SendInputAction(InputType.MOVE, positions, appliedForce);
+                            SendInputAction(InputType.MOVE, positions, positions.DistanceFromScreen, appliedForce);
                         }
                         else if (CheckForStartDrag(cursorPressPosition, positions.CursorPosition))
                         {
@@ -158,7 +158,7 @@ namespace Ultraleap.ScreenControl.Core
                     // when ignoring dragging and moving past the touch-plane.
 
                     pressing = true;
-                    SendInputAction(InputType.DOWN, positions, appliedForce);
+                    SendInputAction(InputType.DOWN, positions, positions.DistanceFromScreen, appliedForce);
                     cursorPressPosition = positions.CursorPosition;
 
                     // If dragging is off, we want to decay the force after a click back to the unclick threshold
@@ -170,7 +170,7 @@ namespace Ultraleap.ScreenControl.Core
                 else if (positions.CursorPosition != previousScreenPos || positions.DistanceFromScreen != previousScreenDistance)
                 {
                     // Send the move event
-                    SendInputAction(InputType.MOVE, positions, appliedForce);
+                    SendInputAction(InputType.MOVE, positions, positions.DistanceFromScreen, appliedForce);
                 }
 
                 if (decayingForce && (appliedForce <= decayThreshold))
@@ -181,7 +181,7 @@ namespace Ultraleap.ScreenControl.Core
             else
             {
                 // show them they have been seen but send no major events as we have only just discovered the hand
-                SendInputAction(InputType.MOVE, positions, appliedForce);
+                SendInputAction(InputType.MOVE, positions, positions.DistanceFromScreen, appliedForce);
             }
 
             // Update stored variables

--- a/ScreenControl/Assets/ScreenControl/Core/Scripts/Interactions/InteractionModules/GrabInteraction.cs
+++ b/ScreenControl/Assets/ScreenControl/Core/Scripts/Interactions/InteractionModules/GrabInteraction.cs
@@ -82,7 +82,7 @@ namespace Ultraleap.ScreenControl.Core
 
         private void HandleInteractions(Leap.Hand hand, float _velocity)
         {
-            SendInputAction(InputType.MOVE, positions, grabDetector.GeneralisedGrabStrength);
+            SendInputAction(InputType.MOVE, positions, positions.DistanceFromScreen, grabDetector.GeneralisedGrabStrength);
             // If already pressing, continue regardless of velocity
             if (grabDetector.IsGrabbing(latestTimestamp, hand, _velocity) && (pressing || _velocity < maxHandVelocity))
             {
@@ -110,7 +110,7 @@ namespace Ultraleap.ScreenControl.Core
 
         private void HandlePress()
         {
-            SendInputAction(InputType.DOWN, positions, grabDetector.GeneralisedGrabStrength);
+            SendInputAction(InputType.DOWN, positions, positions.DistanceFromScreen, grabDetector.GeneralisedGrabStrength);
             dragStartTimer.Restart();
             pressing = true;
             if (instantUnclick && ignoreDragging)
@@ -151,7 +151,7 @@ namespace Ultraleap.ScreenControl.Core
                     }
                     else if (requireClick)
                     {
-                        SendInputAction(InputType.UP, downPositions, grabDetector.GeneralisedGrabStrength);
+                        SendInputAction(InputType.UP, downPositions, positions.DistanceFromScreen, grabDetector.GeneralisedGrabStrength);
                         positioningModule.Stabiliser.StartShrinkingDeadzone(ShrinkType.MOTION_BASED, deadzoneShrinkSpeed);
                         requireClick = false;
                     }
@@ -177,7 +177,7 @@ namespace Ultraleap.ScreenControl.Core
                 {
                     if (!requireHold && !requireClick)
                     {
-                        SendInputAction(InputType.UP, positions, grabDetector.GeneralisedGrabStrength);
+                        SendInputAction(InputType.UP, positions, positions.DistanceFromScreen, grabDetector.GeneralisedGrabStrength);
                     }
                     positioningModule.Stabiliser.StartShrinkingDeadzone(ShrinkType.MOTION_BASED, deadzoneShrinkSpeed);
                 }
@@ -216,7 +216,7 @@ namespace Ultraleap.ScreenControl.Core
                 Gizmos.color = Color.red;
                 Gizmos.DrawWireSphere(-GlobalSettings.virtualScreen.PhysicalScreenPlane.normal * GlobalSettings.virtualScreen.PhysicalScreenPlane.distance, 0.01f);
                 Gizmos.color = Color.green;
-                Gizmos.DrawWireSphere(planeHit_debug + (-GlobalSettings.virtualScreen.VirtualScreenPlane.normal * GlobalSettings.virtualScreen.VirtualScreenPlane.distance), 0.01f);
+                //Gizmos.DrawWireSphere(planeHit_debug + (-GlobalSettings.virtualScreen.VirtualScreenPlane.normal * GlobalSettings.virtualScreen.VirtualScreenPlane.distance), 0.01f);
                 Gizmos.color = Color.yellow;
                 Gizmos.DrawWireSphere(worldPos_debug, 0.01f);
                 Gizmos.color = Color.blue;

--- a/ScreenControl/Assets/ScreenControl/Core/Scripts/Interactions/InteractionModules/HoverAndHoldInteraction.cs
+++ b/ScreenControl/Assets/ScreenControl/Core/Scripts/Interactions/InteractionModules/HoverAndHoldInteraction.cs
@@ -89,11 +89,11 @@ namespace Ultraleap.ScreenControl.Core
                             progressTimer.StopTimer();
                             clickHeld = true;
                             clickingTimer.Restart();
-                            SendInputAction(InputType.DOWN, positions, 0f);
+                            SendInputAction(InputType.DOWN, positions, positions.DistanceFromScreen, 0f);
                         }
                         else
                         {
-                            SendInputAction(InputType.MOVE, positions, progressTimer.Progress);
+                            SendInputAction(InputType.MOVE, positions, positions.DistanceFromScreen, progressTimer.Progress);
 
                             float maxDeadzoneRadius = timerDeadzoneEnlargementDistance + positioningModule.Stabiliser.defaultDeadzoneRadius;
                             float deadzoneRadius = Mathf.Lerp(hoverTriggeredDeadzoneRadius, maxDeadzoneRadius, progressTimer.Progress);
@@ -104,7 +104,7 @@ namespace Ultraleap.ScreenControl.Core
                     {
                         if (!clickAlreadySent && clickingTimer.ElapsedMilliseconds > clickHoldTime)
                         {
-                            SendInputAction(InputType.UP, positions, progressTimer.Progress);
+                            SendInputAction(InputType.UP, positions, positions.DistanceFromScreen, progressTimer.Progress);
                             clickAlreadySent = true;
                         }
                     }
@@ -114,7 +114,7 @@ namespace Ultraleap.ScreenControl.Core
                     if (clickHeld && !clickAlreadySent)
                     {
                         // Handle unclick if move before timer's up
-                        SendInputAction(InputType.UP, positions, progressTimer.Progress);
+                        SendInputAction(InputType.UP, positions, positions.DistanceFromScreen, progressTimer.Progress);
                     }
 
                     progressTimer.ResetTimer();
@@ -131,7 +131,7 @@ namespace Ultraleap.ScreenControl.Core
             }
             else
             {
-                SendInputAction(InputType.MOVE, positions, progressTimer.Progress);
+                SendInputAction(InputType.MOVE, positions, positions.DistanceFromScreen, progressTimer.Progress);
             }
 
             previousHoverPosScreen = _hoverPosition;

--- a/ScreenControl/Assets/ScreenControl/Core/Scripts/Interactions/InteractionModules/InteractionModule.cs
+++ b/ScreenControl/Assets/ScreenControl/Core/Scripts/Interactions/InteractionModules/InteractionModule.cs
@@ -48,9 +48,9 @@ namespace Ultraleap.ScreenControl.Core
         // This is the main update loop of the interaction module
         protected virtual void UpdateData(Leap.Hand hand) { }
 
-        protected void SendInputAction(ScreenControlTypes.InputType _inputType, Positions _positions, float _progressToClick)
+        protected void SendInputAction(ScreenControlTypes.InputType _inputType, Positions _positions, float _distanceFromScreen, float _progressToClick)
         {
-            ScreenControlTypes.CoreInputAction actionData = new ScreenControlTypes.CoreInputAction(latestTimestamp, InteractionType, handType, handChirality, _inputType, _positions, _progressToClick);
+            ScreenControlTypes.CoreInputAction actionData = new ScreenControlTypes.CoreInputAction(latestTimestamp, InteractionType, handType, handChirality, _inputType, _positions, _distanceFromScreen, _progressToClick);
             HandleInputAction?.Invoke(handChirality, handType, actionData);
         }
 

--- a/ScreenControl/Assets/ScreenControl/Core/Scripts/Interactions/InteractionModules/TouchPlanePushInteraction.cs
+++ b/ScreenControl/Assets/ScreenControl/Core/Scripts/Interactions/InteractionModules/TouchPlanePushInteraction.cs
@@ -35,7 +35,7 @@ namespace Ultraleap.ScreenControl.Core
         {
             if (hand == null)
             {
-                SendInputAction(InputType.CANCEL, new Positions(), 0);
+                SendInputAction(InputType.CANCEL, new Positions(), 0, 0);
                 pressing = false;
                 return;
             }
@@ -57,7 +57,7 @@ namespace Ultraleap.ScreenControl.Core
 
             float progressToClick = 1f - Mathf.InverseLerp(screenDistanceAtMaxProgress, screenDistanceAtNoProgress, distanceFromScreen);
 
-            SendInputAction(InputType.MOVE, positions, progressToClick);
+            SendInputAction(InputType.MOVE, positions, distanceFromScreen, progressToClick);
 
             // determine if the fingertip is across one of the surface thresholds (hover/press) and send event
             if (distanceFromScreen < 0f)
@@ -65,7 +65,7 @@ namespace Ultraleap.ScreenControl.Core
                 // we are touching the screen
                 if (!pressing)
                 {
-                    SendInputAction(InputType.DOWN, positions, progressToClick);
+                    SendInputAction(InputType.DOWN, positions, distanceFromScreen, progressToClick);
 
                     downPos = currentCursorPosition;
                     posLastFrame = currentCursorPosition;
@@ -95,7 +95,7 @@ namespace Ultraleap.ScreenControl.Core
                             }
                             else
                             {
-                                SendInputAction(InputType.UP, downPositions, progressToClick);
+                                SendInputAction(InputType.UP, downPositions, distanceFromScreen, progressToClick);
                                 performInstantClick = false;
                             }
                         }
@@ -109,7 +109,7 @@ namespace Ultraleap.ScreenControl.Core
                 {
                     if (!ignoreDragging)
                     {
-                        SendInputAction(InputType.UP, positions, progressToClick);
+                        SendInputAction(InputType.UP, positions, distanceFromScreen, progressToClick);
                     }
 
                     pressing = false;

--- a/ScreenControl/Assets/ScreenControl/Core/Scripts/ScreenControlTypes.cs
+++ b/ScreenControl/Assets/ScreenControl/Core/Scripts/ScreenControlTypes.cs
@@ -20,8 +20,9 @@ namespace Ultraleap.ScreenControl.Core
             public readonly HandChirality Chirality;
             public readonly InputType InputType;
             public readonly Vector2 CursorPosition;
+            public readonly float DistanceFromScreen;
             public readonly float ProgressToClick;
-            public CoreInputAction(long _timestamp, InteractionType _interactionType, HandType _handType, HandChirality _chirality, InputType _inputType, Positions _positions, float _progressToClick)
+            public CoreInputAction(long _timestamp, InteractionType _interactionType, HandType _handType, HandChirality _chirality, InputType _inputType, Positions _positions,float _distanceFromScreen, float _progressToClick)
             {
                 Timestamp = _timestamp;
                 InteractionType = _interactionType;
@@ -29,6 +30,7 @@ namespace Ultraleap.ScreenControl.Core
                 Chirality = _chirality;
                 InputType = _inputType;
                 CursorPosition = _positions.CursorPosition;
+                DistanceFromScreen = _distanceFromScreen;
                 ProgressToClick = _progressToClick;
             }
         }
@@ -94,6 +96,7 @@ namespace Ultraleap.ScreenControl.Core
             public long Timestamp;
             public BitmaskFlags InteractionFlags;
             public Vector2 CursorPosition;
+            public float DistanceFromScreen;
             public float ProgressToClick;
 
             public WebsocketInputAction(CoreInputAction _data)
@@ -104,6 +107,7 @@ namespace Ultraleap.ScreenControl.Core
                                                                  _data.Chirality,
                                                                  _data.InputType);
                 CursorPosition = _data.CursorPosition;
+                DistanceFromScreen = _data.DistanceFromScreen;
                 ProgressToClick = _data.ProgressToClick;
             }
         }


### PR DESCRIPTION
Adjusted VirtualScreen to use distance to the screen as opposed to a virtual screen plane at 5cm from the screen. 

Added DistanceFromScreen to InputActions across both sides of the connection.

Fixed a bug where the WSReceiverQueue would output default inputActions if none were in the queue.